### PR TITLE
Disable script debugging by default

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-set -ex
+set -e
+
+if [ -n "$GADGET_DEBUG" ]; then
+	set -x
+fi
 
 load_modules() {
 	modprobe dwc2


### PR DESCRIPTION
Script debugging got left as on by default, this reverts that and updates the debug variable name to GADGET_DEBUG

Change-type: minor